### PR TITLE
git-p4: handle non utf-8 error messages properly

### DIFF
--- a/git-p4.py
+++ b/git-p4.py
@@ -898,7 +898,7 @@ def p4CmdList(cmd, stdin=None, stdin_mode='w+b', cb=None, skip_info=False,
                     decoded_entry[key] = value
                 # Parse out data if it's an error response
                 if decoded_entry.get('code') == 'error' and 'data' in decoded_entry:
-                    decoded_entry['data'] = decoded_entry['data'].decode()
+                    decoded_entry['data'] = metadata_stream_to_writable_bytes(decoded_entry['data'])
                 entry = decoded_entry
             if skip_info:
                 if 'code' in entry and entry['code'] == 'info':


### PR DESCRIPTION
The code throws UnicodeDecodeError exception when the information in 'data' field of entry being decoded contain non utf-8 characters, even if 'fallback' encoding strategy si defined.

For example: If source p4 repo contains non utf-8 filenames and such a file is excluded by client spec, attempt to report the file as excluded fails due to fact that message contains the file name and .decode call throws.

To fix this, handle the 'data' field using the existing function 'metadata_stream_to_writable_bytes' which follows the fallback encoding strategy gracefully.

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

For a single-commit pull request, please *leave the pull request description
empty*: your commit message itself should describe your changes.

Please read the "guidelines for contributing" linked above!
